### PR TITLE
Add installation guide and info into readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 # Maths-Tutor
+
+Maths-Tutor is an innovative game aimed at revolutionizing math education for the visually impaired. By leveraging inclusive game design and being both free and open source, it strives to make learning mathematics an engaging and enjoyable experience for all learners. This initiative not only helps individuals in judging their abilities but also enhances their mathematical skills in a supportive environment. 
+
+The fact that visually impaired people can now use Abacus and Taylor Frame, along with some software Maths-Tutor underscores the commitment to accessibility and effectiveness in teaching mathematics. The development of Maths-Tutor fills a crucial gap by providing a relevant and accessible alternative to currently used software, ensuring that everyone, regardless of visual ability, has access to quality math education. 
+
+Maths-Tutor seamlessly merges gaming excitement with essential mathematical skills, providing a friendly mentor on your screen for interactive problem-solving. This unique learning experience emphasizes both accuracy and speed, fostering math proficiency while ensuring an enjoyable journey. In today's society, where mathematics holds pivotal importance in academics and daily life, Maths-Tutor becomes a vital resource. It empowers individuals to enhance their mathematical literacy, a crucial skill in our technology-driven era. By offering accessibility and engagement, Maths-Tutor contributes to advancing numeracy and STEM education. More than just a game, it serves as a valuable educational tool, bridging gaps and equipping users with the mathematical skills necessary for contemporary success. Dive into the world of Maths-Tutor to transform math learning into an enjoyable voyage of discovery and accomplishment.
+
+
+## GUI
+### Home screen & About![maths-tutor](https://github.com/SudoSu-bham/maths-tutor/assets/55135022/8667eefa-10f6-4686-a899-2f8cf6521989)
+
+
+## Installation
+
+### For Ubuntu users, install from the Maths-Tutor PPA
+
+Run the following commandsmands:
+
+```bash
+sudo add-apt-repository ppa:nalin-x-linux/maths-tutor
+sudo apt update
+sudo apt-get install maths-tutor
+```
+
+### Installing through git
+
+1. open the terminal and execute the following command:  
+`git clone https://github.com/zendalona/maths-tutor.git`
+
+2. Navigate to the maths-tutor directory using the following command:
+`cd maths-tutor`
+
+3. To install, execute the following command:
+`sudo python3 setup.py install --install-data=/usr`
+
+
+## Controls
+1. Increase speech rate by pressing **(')** apostrophe key
+2. Decrease speech rate by pressing **(;)** semicolon key
+3. To replay the question use Space key
+4. To hear the question in verbose mode use Shift key
+
+5. Press Alt+S to open or hide settings
+- Use settings to change arithmetic operation, difficulty level, load questions, speech language, voice, etc.
+
+
+**for more info visit**  
+[Maths-Tutor website](https://zendalona.com/accessible-maths-tutor/)


### PR DESCRIPTION
The `README` file was empty there was no information related to `Maths-Tutor` and about how to install it.
This PR will add detail about `Maths-Tutor` and also I have added installation guide with an image of GUI of the game.

There is some change in installation steps  
[Installation guide's](https://zendalona.com/Maths%20tutor%20installation%20guide/) `Step 2` of git installation methods seems wrong. I have made changes to  `Step 2` and tested it in ubuntu, it is working correctly.
